### PR TITLE
Generic DatabindingFragment implementation

### DIFF
--- a/app/src/main/java/de/thm/mobiletech/hideandguess/DrawBlurFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/DrawBlurFragment.kt
@@ -1,48 +1,23 @@
 package de.thm.mobiletech.hideandguess
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.databinding.ObservableField
-import androidx.navigation.NavController
-import androidx.navigation.fragment.NavHostFragment
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import de.thm.mobiletech.hideandguess.databinding.FragmentDrawBlurBinding
+import de.thm.mobiletech.hideandguess.util.DatabindingFragment
 
 /**
  * A simple [Fragment] subclass using data binding.
  */
-class DrawBlurFragment : Fragment() {
+class DrawBlurFragment : DatabindingFragment<FragmentDrawBlurBinding>(R.layout.fragment_draw_blur) {
 
-    private lateinit var binding: FragmentDrawBlurBinding
-    private lateinit var navController: NavController
     private val args: DrawBlurFragmentArgs by navArgs() // Get SafeArgs from Navigation
-
     val username : ObservableField<String> = ObservableField()
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        // Inflate the layout for this fragment using data binding
-        binding = DataBindingUtil.inflate(
-            inflater, R.layout.fragment_draw_blur, container, false
-        )
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.context = this // Set binding variable used in layout
-        return binding.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        // Find and assign navController
-        val navHostFragment = requireActivity().supportFragmentManager
-            .findFragmentById(R.id.navHost) as NavHostFragment
-        navController = navHostFragment.navController
 
         // Add listener for multiplier display
         binding.blurDrawView.currentMultiplier.observe(viewLifecycleOwner) {
@@ -52,6 +27,10 @@ class DrawBlurFragment : Fragment() {
 
         // Update username with args
         username.set(args.username)
+    }
+
+    override fun setBindingContext() {
+        binding.context = this
     }
 
     fun resetButtonClicked() {

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/DrawBlurFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/DrawBlurFragment.kt
@@ -6,12 +6,12 @@ import androidx.databinding.ObservableField
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import de.thm.mobiletech.hideandguess.databinding.FragmentDrawBlurBinding
-import de.thm.mobiletech.hideandguess.util.DatabindingFragment
+import de.thm.mobiletech.hideandguess.util.DataBindingFragment
 
 /**
  * A simple [Fragment] subclass using data binding.
  */
-class DrawBlurFragment : DatabindingFragment<FragmentDrawBlurBinding>(R.layout.fragment_draw_blur) {
+class DrawBlurFragment : DataBindingFragment<FragmentDrawBlurBinding>(R.layout.fragment_draw_blur) {
 
     private val args: DrawBlurFragmentArgs by navArgs() // Get SafeArgs from Navigation
     val username : ObservableField<String> = ObservableField()

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/LoginFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/LoginFragment.kt
@@ -1,9 +1,9 @@
 package de.thm.mobiletech.hideandguess
 
 import de.thm.mobiletech.hideandguess.databinding.FragmentLoginBinding
-import de.thm.mobiletech.hideandguess.util.DatabindingFragment
+import de.thm.mobiletech.hideandguess.util.DataBindingFragment
 
-class LoginFragment : DatabindingFragment<FragmentLoginBinding>(R.layout.fragment_login) {
+class LoginFragment : DataBindingFragment<FragmentLoginBinding>(R.layout.fragment_login) {
 
     override fun setBindingContext() {
         binding.context = this

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/LoginFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/LoginFragment.kt
@@ -1,47 +1,16 @@
 package de.thm.mobiletech.hideandguess
 
-import android.os.Bundle
-import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
-import androidx.navigation.NavController
-import androidx.navigation.fragment.NavHostFragment
 import de.thm.mobiletech.hideandguess.databinding.FragmentLoginBinding
-import de.thm.mobiletech.hideandguess.databinding.FragmentMainMenuBinding
+import de.thm.mobiletech.hideandguess.util.DatabindingFragment
 
+class LoginFragment : DatabindingFragment<FragmentLoginBinding>(R.layout.fragment_login) {
 
-class LoginFragment : Fragment() {
-
-    private lateinit var binding: FragmentLoginBinding
-    private lateinit var navController: NavController
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        // Inflate layout using data binding
-        binding = DataBindingUtil.inflate(
-            inflater, R.layout.fragment_login, container, false
-        )
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.context = this // Set binding variable used in layout
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        // Find and assign navController
-        val navHostFragment = requireActivity().supportFragmentManager
-            .findFragmentById(R.id.navHost) as NavHostFragment
-        navController = navHostFragment.navController
+    override fun setBindingContext() {
+        binding.context = this
     }
 
     fun openRegisterFragment() {
         val action = LoginFragmentDirections.actionLoginFragmentToRegisterFragment()
         navController.navigate(action)
     }
-
 }

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/MainActivity.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/MainActivity.kt
@@ -1,7 +1,7 @@
 package de.thm.mobiletech.hideandguess
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/MainMenuFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/MainMenuFragment.kt
@@ -2,12 +2,12 @@ package de.thm.mobiletech.hideandguess
 
 import androidx.fragment.app.Fragment
 import de.thm.mobiletech.hideandguess.databinding.FragmentMainMenuBinding
-import de.thm.mobiletech.hideandguess.util.DatabindingFragment
+import de.thm.mobiletech.hideandguess.util.DataBindingFragment
 
 /**
  * A simple [Fragment] subclass using data binding.
  */
-class MainMenuFragment : DatabindingFragment<FragmentMainMenuBinding>(R.layout.fragment_main_menu) {
+class MainMenuFragment : DataBindingFragment<FragmentMainMenuBinding>(R.layout.fragment_main_menu) {
 
     override fun setBindingContext() {
         binding.context = this

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/MainMenuFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/MainMenuFragment.kt
@@ -1,43 +1,16 @@
 package de.thm.mobiletech.hideandguess
 
-import android.os.Bundle
 import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
-import androidx.navigation.NavController
-import androidx.navigation.fragment.NavHostFragment
 import de.thm.mobiletech.hideandguess.databinding.FragmentMainMenuBinding
+import de.thm.mobiletech.hideandguess.util.DatabindingFragment
 
 /**
  * A simple [Fragment] subclass using data binding.
  */
-class MainMenuFragment : Fragment() {
+class MainMenuFragment : DatabindingFragment<FragmentMainMenuBinding>(R.layout.fragment_main_menu) {
 
-    private lateinit var binding: FragmentMainMenuBinding
-    private lateinit var navController: NavController
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        // Inflate layout using data binding
-        binding = DataBindingUtil.inflate(
-            inflater, R.layout.fragment_main_menu, container, false
-        )
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.context = this // Set binding variable used in layout
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        // Find and assign navController
-        val navHostFragment = requireActivity().supportFragmentManager
-            .findFragmentById(R.id.navHost) as NavHostFragment
-        navController = navHostFragment.navController
+    override fun setBindingContext() {
+        binding.context = this
     }
 
     fun openDrawFragment() {

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/RegisterFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/RegisterFragment.kt
@@ -1,9 +1,9 @@
 package de.thm.mobiletech.hideandguess
 
 import de.thm.mobiletech.hideandguess.databinding.FragmentRegisterBinding
-import de.thm.mobiletech.hideandguess.util.DatabindingFragment
+import de.thm.mobiletech.hideandguess.util.DataBindingFragment
 
-class RegisterFragment : DatabindingFragment<FragmentRegisterBinding>(R.layout.fragment_register) {
+class RegisterFragment : DataBindingFragment<FragmentRegisterBinding>(R.layout.fragment_register) {
 
     override fun setBindingContext() {
         binding.context = this

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/RegisterFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/RegisterFragment.kt
@@ -1,42 +1,12 @@
 package de.thm.mobiletech.hideandguess
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
-import androidx.fragment.app.Fragment
-import androidx.navigation.NavController
-import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.fragment.findNavController
-import com.google.android.material.textfield.TextInputEditText
 import de.thm.mobiletech.hideandguess.databinding.FragmentRegisterBinding
+import de.thm.mobiletech.hideandguess.util.DatabindingFragment
 
-class RegisterFragment : Fragment() {
+class RegisterFragment : DatabindingFragment<FragmentRegisterBinding>(R.layout.fragment_register) {
 
-    private lateinit var binding: FragmentRegisterBinding
-    private lateinit var navController: NavController
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        // Inflate layout using data binding
-        binding = DataBindingUtil.inflate(
-            inflater, R.layout.fragment_register, container, false
-        )
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.context = this // Set binding variable used in layout
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        // Find and assign navController
-        val navHostFragment = requireActivity().supportFragmentManager
-            .findFragmentById(R.id.navHost) as NavHostFragment
-        navController = navHostFragment.navController
+    override fun setBindingContext() {
+        binding.context = this
     }
 
     fun register() {
@@ -46,5 +16,4 @@ class RegisterFragment : Fragment() {
         if (password != passwordConfirm)
             binding.editTextRegisterPasswordConfirm.error = "Passwörter stimmen nicht überein!"
     }
-
 }

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/util/DataBindingFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/util/DataBindingFragment.kt
@@ -20,11 +20,11 @@ import de.thm.mobiletech.hideandguess.R
  *
  * **Example:**
  * ```
- * TestFragment : DatabindingFragment<FragmentTestBinding>(R.layout.fragment_test)
+ * TestFragment : DataBindingFragment<FragmentTestBinding>(R.layout.fragment_test)
  * ```
  * @param layout The R.layout.layout_id reference to inflate.
  * */
-abstract class DatabindingFragment<BD : ViewDataBinding>(val layout: Int) :
+abstract class DataBindingFragment<BD : ViewDataBinding>(val layout: Int) :
     Fragment(),
     IDatabindingContext {
 

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/util/DatabindingFragment.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/util/DatabindingFragment.kt
@@ -1,0 +1,58 @@
+package de.thm.mobiletech.hideandguess.util
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+import de.thm.mobiletech.hideandguess.R
+
+/**
+ * Generic fragment with DataBinding.
+ * Inflates the provided layout via [DataBindingUtil] and sets up
+ * binding and navController variables.
+ *
+ * The binding reference is of type [BD], where BD is the concrete Binding class.
+ *
+ * **Example:**
+ * ```
+ * TestFragment : DatabindingFragment<FragmentTestBinding>(R.layout.fragment_test)
+ * ```
+ * @param layout The R.layout.layout_id reference to inflate.
+ * */
+abstract class DatabindingFragment<BD : ViewDataBinding>(val layout: Int) :
+    Fragment(),
+    IDatabindingContext {
+
+    lateinit var binding: BD
+    lateinit var navController: NavController
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        // Inflate layout using data binding
+        binding = DataBindingUtil.inflate(
+            inflater, layout, container, false
+        )
+        binding.lifecycleOwner = viewLifecycleOwner
+
+        // This sets the layout data variable. It needs to be implemented by the concrete class.
+        setBindingContext()
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Find and assign navController
+        val navHostFragment = requireActivity().supportFragmentManager
+            .findFragmentById(R.id.navHost) as NavHostFragment
+        navController = navHostFragment.navController
+    }
+}

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/util/IDatabindingContext.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/util/IDatabindingContext.kt
@@ -1,0 +1,18 @@
+package de.thm.mobiletech.hideandguess.util
+
+/**
+ * This interface enforces that all classes extending [DatabindingFragment]
+ * have to implement a method to set their data binding layout variable.
+ * Content of said method should be along the line of
+ *
+ * `binding.<contextVariable> = this`
+ * */
+sealed interface IDatabindingContext {
+    /**
+     * This method is called in [DatabindingFragment.onCreateView].
+     * It should set the data binding variable of the layout to the fragment instance.
+     *
+     * e.g. `binding.context = this`
+     * */
+    fun setBindingContext()
+}

--- a/app/src/main/java/de/thm/mobiletech/hideandguess/util/IDatabindingContext.kt
+++ b/app/src/main/java/de/thm/mobiletech/hideandguess/util/IDatabindingContext.kt
@@ -1,7 +1,7 @@
 package de.thm.mobiletech.hideandguess.util
 
 /**
- * This interface enforces that all classes extending [DatabindingFragment]
+ * This interface enforces that all classes extending [DataBindingFragment]
  * have to implement a method to set their data binding layout variable.
  * Content of said method should be along the line of
  *
@@ -9,7 +9,7 @@ package de.thm.mobiletech.hideandguess.util
  * */
 sealed interface IDatabindingContext {
     /**
-     * This method is called in [DatabindingFragment.onCreateView].
+     * This method is called in [DataBindingFragment.onCreateView].
      * It should set the data binding variable of the layout to the fragment instance.
      *
      * e.g. `binding.context = this`


### PR DESCRIPTION
Refactored all fragments to extend a generic `DataBindingFragment` instead of setting up the `binding` & `navController` references in their override functions. This massively reduces boilerplate code & very similar `onCreateView` overrides for data binding.

The generic implementation enforces the concrete type of the binding and the layout ID to be set in the subclass header, so both are defined at compile time.